### PR TITLE
chore: normalize from fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ node_modules
 .todo
 backup
 
-
 # Turbo
 turbo-*.log
 
@@ -142,3 +141,4 @@ yarn-error.log*
 
 # Tauri
 target/
+productiv.code-workspace

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A Cross Platform Monorepo featuring Next.js + tRPC + Tauri + Vite + Expo (React 
 
 [![Stars](https://img.shields.io/github/stars/zeno-oss/zeno?style=social)](https://github.com/zeno-oss/zeno)
 
-## Provides you with a end-to-end typesafe:
-- Desktop Application (Windows, Mac and Linux)
-- Mobile Application (iOS, Android)
-- Web Application (Next.js)
-- Backend Server (tRPC)
+## Provides you with a end-to-end typesafety
 
+- [x] Desktop Application (Windows, Mac and Linux)
+- [x] Mobile Application (iOS, Android)
+- [x] Web Application (Next.js)
+- [x] Backend Server (tRPC)
 
 ## Screenshots
 
@@ -21,25 +21,25 @@ Requires Yarn (if you don't have yarn, install it by `npm install -g yarn`)
 
 Install Dependencies
 
-```
+```ps1
 yarn
 ```
 
-To Run The Website/Backend (Next.js + tRPC) at http://localhost:3000:
+To Run The Website/Backend (Next.js + tRPC) at <http://localhost:3000>:
 
-```
+```ps1
 yarn web dev
 ```
 
 To Run The Desktop App (Tauri + Vite):
 
-```
+```ps1
 yarn desktop dev
 ```
 
 To Run The Mobile Expo App:
 
-```
+```ps1
 yarn mobile dev
 ```
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -21,7 +21,7 @@
     "@vitejs/plugin-react-swc": "^3.0.1",
     "autoprefixer": "^10.4.13",
     "postcss": "^8.4.21",
-    "tailwindcss": "^3.2.4",
+    "tailwindcss": "^3.2.7",
     "vite": "^4.0.4"
   }
 }

--- a/colors.js
+++ b/colors.js
@@ -1,10 +1,8 @@
-/**
- * Specify your custom tailwind colors here.
- */
 module.exports = {
   black: "#141414",
   white: "#fff",
   gray: "#9F9F9F",
+  "gray-50": "#E3E3E3",
   lightGray: "#E3E3E3",
   banana: "#FCE114",
   darkBanana: "#E1CB13",

--- a/packages/server/env/schema.mjs
+++ b/packages/server/env/schema.mjs
@@ -17,6 +17,7 @@ export const serverSchema = z.object({
  */
 export const serverEnv = {
   DATABASE_URL: process.env.DATABASE_URL,
+  // @ts-ignore
   NODE_ENV: process.env.NODE_ENV,
 };
 

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -6,10 +6,11 @@ generator client {
 }
 
 datasource db {
-    provider = "mysql"
+    provider = "postgresql"
     relationMode = "prisma"
     url      = env("DATABASE_URL")
-    shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
+    // shadowDatabaseUrl = env("DATABASE_URL")
+    // shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 
 model Task {

--- a/packages/variables/colors.ts
+++ b/packages/variables/colors.ts
@@ -1,4 +1,26 @@
-import PALETTE from "../../colors";
+const PALETTE = {
+  black: "#141414",
+  white: "#fff",
+  gray: "#9F9F9F",
+  // "gray-50": "#E3E3E3",
+  lightGray: "#E3E3E3",
+  banana: "#FCE114",
+  darkBanana: "#E1CB13",
+  turquoise: "#4BEED1",
+  darkTurquoise: "#1AA58C",
+  pictonBlue: "#46D2EF",
+  darkPictonBlue: "#59C7DE",
+  vodka: "#B7ADFF",
+  darkVodka: "#A59CE6",
+  radicalRed: "#F82867",
+  darkRadicalRed: "#E11D5A",
+  coral: "#F5815C",
+  darkCoral: "#E16A4B",
+  dodgerBlue: "#2B8CFB",
+  darkDodgerBlue: "#1E6ED8",
+  plumPurple: "#A949C1",
+  darkPlumPurple: "#8F3DAF",
+};
 
 const TASKS_PALETTE = {
   BANANA: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6926,7 +6926,7 @@ postcss-selector-parser@^6.0.10:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss-selector-parser@^6.0.6, postcss-selector-parser@^6.0.9:
+postcss-selector-parser@^6.0.11, postcss-selector-parser@^6.0.6, postcss-selector-parser@^6.0.9:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz#2e41dc39b7ad74046e1615185185cd0b17d0c8dc"
   integrity sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==
@@ -6948,7 +6948,7 @@ postcss@8.4.14:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-postcss@^8.4.12, postcss@^8.4.18, postcss@^8.4.20, postcss@^8.4.21:
+postcss@^8.0.9, postcss@^8.4.12, postcss@^8.4.18, postcss@^8.4.20, postcss@^8.4.21:
   version "8.4.21"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.21.tgz#c639b719a57efc3187b13a1d765675485f4134f4"
   integrity sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==
@@ -8220,6 +8220,35 @@ tailwindcss@^3.2.4:
     postcss-load-config "^3.1.4"
     postcss-nested "6.0.0"
     postcss-selector-parser "^6.0.10"
+    postcss-value-parser "^4.2.0"
+    quick-lru "^5.1.1"
+    resolve "^1.22.1"
+
+tailwindcss@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.2.7.tgz#5936dd08c250b05180f0944500c01dce19188c07"
+  integrity sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==
+  dependencies:
+    arg "^5.0.2"
+    chokidar "^3.5.3"
+    color-name "^1.1.4"
+    detective "^5.2.1"
+    didyoumean "^1.2.2"
+    dlv "^1.1.3"
+    fast-glob "^3.2.12"
+    glob-parent "^6.0.2"
+    is-glob "^4.0.3"
+    lilconfig "^2.0.6"
+    micromatch "^4.0.5"
+    normalize-path "^3.0.0"
+    object-hash "^3.0.0"
+    picocolors "^1.0.0"
+    postcss "^8.0.9"
+    postcss-import "^14.1.0"
+    postcss-js "^4.0.0"
+    postcss-load-config "^3.1.4"
+    postcss-nested "6.0.0"
+    postcss-selector-parser "^6.0.11"
     postcss-value-parser "^4.2.0"
     quick-lru "^5.1.1"
     resolve "^1.22.1"


### PR DESCRIPTION
- update tailwind
- lint

`colors.js` isnt being used atm. Upstream's import wasn't working so I temporarily copied to `packages/variables/colors.ts` but I like the idea of having one centralized palette at the mono root.